### PR TITLE
Support python 3.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 sg.yml
 *.pyc
 pairs.log
+.idea
+.python-version

--- a/pair.py
+++ b/pair.py
@@ -1,7 +1,5 @@
 # coding: utf-8
 
-from __future__ import unicode_literals, print_function
-
 import os
 import random
 import sendgrid

--- a/pair.py
+++ b/pair.py
@@ -6,7 +6,7 @@ import os
 import random
 import sendgrid
 import yaml
-from itertools import izip_longest
+from itertools import zip_longest
 from datetime import datetime
 
 
@@ -62,7 +62,7 @@ class CodePairs(object):
         random.shuffle(self.hobbits)
         random.shuffle(self.enchantresses)
 
-        zipped = list(izip_longest(self.hobbits, self.enchantresses))
+        zipped = list(zip_longest(self.hobbits, self.enchantresses))
         no_pair = map(lambda p: p[0] or p[1], filter(lambda p: not p[0] or not p[1], zipped))
         pairs = filter(lambda p: p[0] and p[1], zipped)
 

--- a/pair.py
+++ b/pair.py
@@ -36,11 +36,11 @@ class CodePairs(object):
 
     def load_config(self):
         with open(self.config_path, 'r') as f:
-            return yaml.load(f.read())
+            return yaml.safe_load(f.read())
 
     def load_sg(self):
         with open(self.sg_path, 'r') as f:
-            return yaml.load(f.read())
+            return yaml.safe_load(f.read())
 
     @property
     def sg_client(self):

--- a/pair.py
+++ b/pair.py
@@ -63,8 +63,8 @@ class CodePairs(object):
         random.shuffle(self.enchantresses)
 
         zipped = list(zip_longest(self.hobbits, self.enchantresses))
-        no_pair = map(lambda p: p[0] or p[1], filter(lambda p: not p[0] or not p[1], zipped))
-        pairs = filter(lambda p: p[0] and p[1], zipped)
+        no_pair = list(map(lambda p: p[0] or p[1], filter(lambda p: not p[0] or not p[1], zipped)))
+        pairs = list(filter(lambda p: p[0] and p[1], zipped))
 
         # Handle the odd numbers
         one = two = None


### PR DESCRIPTION
I don't see any reason to support Python 2, so made those changes here. I am updating sendgrid as well, but wanted to keep these changes isolated from that change.

(Also for context, planning to fire this back up for a code review pairing initiative)