### PR TITLE
Fix SendGrid API bugs

### DIFF
--- a/email_utils.py
+++ b/email_utils.py
@@ -19,7 +19,7 @@ def _build_email(sender, recipients, subject, content):
     message.from_email = sender
     message.to = recipients
     message.subject = subject
-    message.add_content(content)
+    message.add_content(content, 'text/html')
     return message
 
 

--- a/email_utils.py
+++ b/email_utils.py
@@ -20,6 +20,7 @@ def _build_email(sender, recipients, subject, content):
     message.to = recipients
     message.subject = subject
     message.add_content(content)
+    return message
 
 
 def _get_recipients_from_usernames(usernames):

--- a/pair.py
+++ b/pair.py
@@ -2,8 +2,10 @@
 
 import os
 import random
-import yaml
 from itertools import zip_longest
+
+import yaml
+from python_http_client import HTTPError
 
 from email_utils import build_email_from_usernames, get_email_client
 
@@ -71,9 +73,10 @@ class CodePairs(object):
 
     def email_pairs(self):
         pairs = self._generate_pairs()
-        print(pairs)
         for usernames in pairs:
             message = build_email_from_usernames(self.email_sender, usernames)
-            status, msg = self.email_client.send(message)
-            print(status)
-            print(msg)
+            try:
+                response = self.email_client.send(message)
+            except HTTPError as e:
+                print(e)
+            print(f"Request received with response: {response.status_code}\n{response.body}")

--- a/tests/test_email_utils.py
+++ b/tests/test_email_utils.py
@@ -7,10 +7,17 @@ class SendgridTests(TestCase):
 
     def test_email_for_pair_succeeds(self):
         usernames = ('user', 'user2')
-        build_email_from_usernames('sender', usernames)  # should not raise
+        message = build_email_from_usernames('sender', usernames)
+        self.assertIsNotNone(message.get())
 
     def test_email_for_trio_succeeds(self):
         usernames = ('user', 'user2', 'user3')
-        build_email_from_usernames('sender', usernames)  # should not raise
+        message = build_email_from_usernames('sender', usernames)
+        self.assertIsNotNone(message.get())
 
-
+    def test_recipients_is_correct(self):
+        usernames = ('user', 'user2')
+        message = build_email_from_usernames('sender', usernames)
+        msg_json = message.get()
+        recipients = [p['email'] for p in msg_json['personalizations'][0]['to']]
+        self.assertEqual(recipients, ['user@dimagi.com', 'user2@dimagi.com'])


### PR DESCRIPTION
The email utils wasn't returning the built message (my bad). Fixed that. And then the content type needs to be specified when adding content to the email message that will be sent to sendgrid.