### PR TITLE
Use setup-python@v4

### DIFF
--- a/.github/workflows/generate-pairs.yml
+++ b/.github/workflows/generate-pairs.yml
@@ -12,7 +12,7 @@ jobs:
       FROM_EMAIL: ${{ secrets.FROM_EMAIL }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
       - name: Get current day

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
       - name: install test requirements


### PR DESCRIPTION
There are deprecation warnings on both github actions about using `set-output`. I'm not positive this will resolve that, but have a feeling it might.

Update: resolved ✅  (based on the test run that no longer has a deprecation warning)